### PR TITLE
feat: add nock mocks for MOEX API in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "node-fetch": "^2.6.7"
       },
       "devDependencies": {
-        "jest": "^28.1.3"
+        "jest": "^28.1.3",
+        "nock": "^13.5.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2454,6 +2455,13 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -2585,6 +2593,21 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/nock": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
+      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -2843,6 +2866,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/react-is": {
@@ -5217,6 +5250,12 @@
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5314,6 +5353,17 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "nock": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
+      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      }
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -5495,6 +5545,12 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "react-is": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {
-    "jest": "^28.1.3"
+    "jest": "^28.1.3",
+    "nock": "^13.5.4"
   }
 }

--- a/test/_mocks.js
+++ b/test/_mocks.js
@@ -1,206 +1,206 @@
-const nock = require('nock');
+const nock = require("nock");
 
 const createSecuritiesData = (start, count) => {
-    const data = [];
-    for (let i = 0; i < count; i++) {
-        const secid = `SEC${String(start + i).padStart(4, '0')}`;
-        data.push([
-            secid, `Security ${start + i}`, '123', `Full name ${start + i}`, 'ISIN123',
-            1, 1, 'Issuer', 'INN123', 'OKPO123', 'stock', 'group1', 'CETS', null
-        ]);
-    }
-    return data;
+	const data = [];
+	for (let i = 0; i < count; i++) {
+		const secid = `SEC${String(start + i).padStart(4, "0")}`;
+		data.push([
+			secid, `Security ${start + i}`, "123", `Full name ${start + i}`, "ISIN123",
+			1, 1, "Issuer", "INN123", "OKPO123", "stock", "group1", "CETS", null
+		]);
+	}
+	return data;
 };
 
 const createMarketData = (count) => {
-    const data = [];
-    for (let i = 0; i < count; i++) {
-        const secid = `SEC${String(i).padStart(4, '0')}`;
-        data.push([
-            secid, 'CETS', 100 + i, 90 + i, 110 + i, 80 + i, 95 + i, 5 + i,
-            1000 + i * 10, 5000 + i * 50, 10000 + i * 100, 50000 + i * 500,
-            100000 + i * 1000, 500 + i * 5, 2500 + i * 25, 12500 + i * 125, 'RUR', '2024-01-01'
-        ]);
-    }
-    return data;
+	const data = [];
+	for (let i = 0; i < count; i++) {
+		const secid = `SEC${String(i).padStart(4, "0")}`;
+		data.push([
+			secid, "CETS", 100 + i, 90 + i, 110 + i, 80 + i, 95 + i, 5 + i,
+			1000 + i * 10, 5000 + i * 50, 10000 + i * 100, 50000 + i * 500,
+			100000 + i * 1000, 500 + i * 5, 2500 + i * 25, 12500 + i * 125, "RUR", "2024-01-01"
+		]);
+	}
+	return data;
 };
 
 const setupMocks = () => {
-    nock.disableNetConnect();
+	nock.disableNetConnect();
 
-    // engines endpoint - camelCase
-    nock('https://iss.moex.com').get('/iss/engines.json').reply(200, {
-        engines: {
-            columns: ['name', 'description'],
-            data: [['stock', 'Stocks'], ['currency', 'Currency'], ['futures', 'Futures'], ['bond', 'Bonds'], ['marketdata', 'Market Data']]
-        }
-    }).persist();
+	// engines endpoint - camelCase
+	nock("https://iss.moex.com").get("/iss/engines.json").reply(200, {
+		engines: {
+			columns: ["name", "description"],
+			data: [["stock", "Stocks"], ["currency", "Currency"], ["futures", "Futures"], ["bond", "Bonds"], ["marketdata", "Market Data"]]
+		}
+	}).persist();
 
-    // index endpoint - camelCase
-    nock('https://iss.moex.com').get('/iss.json').reply(200, {
-        engines: { columns: ['name'], data: [['stock'], ['currency'], ['futures'], ['bond'], ['marketdata']] },
-        markets: { columns: ['name'], data: [['shares'], ['selt'], ['index'], ['derivatives'], ['bonds']] },
-        boards: { columns: ['boardid'], data: [['CETS'], ['TQBR'], ['RFUD'], ['RFLS'], ['INAV']] }
-    }).persist();
+	// index endpoint - camelCase
+	nock("https://iss.moex.com").get("/iss.json").reply(200, {
+		engines: { columns: ["name"], data: [["stock"], ["currency"], ["futures"], ["bond"], ["marketdata"]] },
+		markets: { columns: ["name"], data: [["shares"], ["selt"], ["index"], ["derivatives"], ["bonds"]] },
+		boards: { columns: ["boardid"], data: [["CETS"], ["TQBR"], ["RFUD"], ["RFLS"], ["INAV"]] }
+	}).persist();
 
-    // securities definitions - camelCase, query(true) для гибкого сопоставления
-    nock('https://iss.moex.com').get('/iss/securities.json').query(true).reply(function(uri) {
-        const url = new URL(uri, 'https://iss.moex.com');
-        const start = parseInt(url.searchParams.get('start') || '0', 10);
-        const count = Math.min(100, 500 - start);
-        const data = createSecuritiesData(start, count);
-        return [200, {
-            securities: {
-                columns: ['secid', 'shortname', 'regnumber', 'name', 'isin', 'is_traded', 'emitent_id', 'emitent_title', 'emitent_inn', 'emitent_okpo', 'type', 'group', 'primary_boardid', 'marketprice_boardid'],
-                data: data
-            }
-        }];
-    }).persist();
+	// securities definitions - camelCase, query(true) для гибкого сопоставления
+	nock("https://iss.moex.com").get("/iss/securities.json").query(true).reply(function(uri) {
+		const url = new URL(uri, "https://iss.moex.com");
+		const start = parseInt(url.searchParams.get("start") || "0", 10);
+		const count = Math.min(100, 500 - start);
+		const data = createSecuritiesData(start, count);
+		return [200, {
+			securities: {
+				columns: ["secid", "shortname", "regnumber", "name", "isin", "is_traded", "emitent_id", "emitent_title", "emitent_inn", "emitent_okpo", "type", "group", "primary_boardid", "marketprice_boardid"],
+				data: data
+			}
+		}];
+	}).persist();
 
-    // markets endpoint - camelCase
-    nock('https://iss.moex.com').get('/iss/engines/stock/markets.json').reply(200, {
-        markets: {
-            columns: ['NAME', 'DESCRIPTION'],
-            data: [['shares', 'Shares'], ['index', 'Indexes'], ['derivatives', 'Derivatives'], ['bonds', 'Bonds'], ['futures', 'Futures']]
-        }
-    }).persist();
+	// markets endpoint - camelCase
+	nock("https://iss.moex.com").get("/iss/engines/stock/markets.json").reply(200, {
+		markets: {
+			columns: ["NAME", "DESCRIPTION"],
+			data: [["shares", "Shares"], ["index", "Indexes"], ["derivatives", "Derivatives"], ["bonds", "Bonds"], ["futures", "Futures"]]
+		}
+	}).persist();
 
-    // boards endpoint - camelCase
-    nock('https://iss.moex.com').get('/iss/engines/currency/markets/selt/boards.json').reply(200, {
-        boards: {
-            columns: ['boardid', 'engine', 'market', 'boardname', 'active', 'primary'],
-            data: [['CETS', 'currency', 'selt', 'Main', 1, 1], ['TQBR', 'currency', 'selt', 'Secondary', 1, 0]]
-        }
-    }).persist();
+	// boards endpoint - camelCase
+	nock("https://iss.moex.com").get("/iss/engines/currency/markets/selt/boards.json").reply(200, {
+		boards: {
+			columns: ["boardid", "engine", "market", "boardname", "active", "primary"],
+			data: [["CETS", "currency", "selt", "Main", 1, 1], ["TQBR", "currency", "selt", "Secondary", 1, 0]]
+		}
+	}).persist();
 
-    // security definitions - camelCase
-    nock('https://iss.moex.com').get('/iss/securities/USD000UTSTOM.json').reply(200, {
-        securities: {
-            columns: ['secid', 'shortname', 'regnumber', 'name', 'isin', 'is_traded', 'emitent_id', 'emitent_title', 'emitent_inn', 'emitent_okpo', 'type', 'group', 'primary_boardid', 'marketprice_boardid'],
-            data: [['USD000UTSTOM', 'USD/RUB', '123', 'US Dollar', 'US123', 1, 1, 'Issuer', 'INN', 'OKPO', 'currency', 'selt', 'CETS', null]]
-        },
-        description: { columns: ['name', 'value'], data: [['description', 'USD/RUB Security']] },
-        boards: { columns: ['boardid', 'engine', 'market', 'boardname', 'active', 'primary'], data: [['CETS', 'currency', 'selt', 'Main', 1, 1]] }
-    }).persist();
+	// security definitions - camelCase
+	nock("https://iss.moex.com").get("/iss/securities/USD000UTSTOM.json").reply(200, {
+		securities: {
+			columns: ["secid", "shortname", "regnumber", "name", "isin", "is_traded", "emitent_id", "emitent_title", "emitent_inn", "emitent_okpo", "type", "group", "primary_boardid", "marketprice_boardid"],
+			data: [["USD000UTSTOM", "USD/RUB", "123", "US Dollar", "US123", 1, 1, "Issuer", "INN", "OKPO", "currency", "selt", "CETS", null]]
+		},
+		description: { columns: ["name", "value"], data: [["description", "USD/RUB Security"]] },
+		boards: { columns: ["boardid", "engine", "market", "boardname", "active", "primary"], data: [["CETS", "currency", "selt", "Main", 1, 1]] }
+	}).persist();
 
-    nock('https://iss.moex.com').get('/iss/securities/IMOEX.json').reply(200, {
-        securities: {
-            columns: ['secid', 'shortname', 'regnumber', 'name', 'isin', 'is_traded', 'emitent_id', 'emitent_title', 'emitent_inn', 'emitent_okpo', 'type', 'group', 'primary_boardid', 'marketprice_boardid'],
-            data: [['IMOEX', 'MOEX Index', '123', 'Moscow Exchange Index', 'RU123', 1, 1, 'Issuer', 'INN', 'OKPO', 'stock', 'index', 'TQBR', null]]
-        },
-        description: { columns: ['name', 'value'], data: [['description', 'MOEX Index']] },
-        boards: { columns: ['boardid', 'engine', 'market', 'boardname', 'active', 'primary'], data: [['TQBR', 'stock', 'index', 'Main', 1, 1]] }
-    }).persist();
+	nock("https://iss.moex.com").get("/iss/securities/IMOEX.json").reply(200, {
+		securities: {
+			columns: ["secid", "shortname", "regnumber", "name", "isin", "is_traded", "emitent_id", "emitent_title", "emitent_inn", "emitent_okpo", "type", "group", "primary_boardid", "marketprice_boardid"],
+			data: [["IMOEX", "MOEX Index", "123", "Moscow Exchange Index", "RU123", 1, 1, "Issuer", "INN", "OKPO", "stock", "index", "TQBR", null]]
+		},
+		description: { columns: ["name", "value"], data: [["description", "MOEX Index"]] },
+		boards: { columns: ["boardid", "engine", "market", "boardname", "active", "primary"], data: [["TQBR", "stock", "index", "Main", 1, 1]] }
+	}).persist();
 
-    nock('https://iss.moex.com').get('/iss/securities/RTSI.json').reply(200, {
-        securities: {
-            columns: ['secid', 'shortname', 'regnumber', 'name', 'isin', 'is_traded', 'emitent_id', 'emitent_title', 'emitent_inn', 'emitent_okpo', 'type', 'group', 'primary_boardid', 'marketprice_boardid'],
-            data: [['RTSI', 'RTS Index', '123', 'RTS Index', 'RU123', 1, 1, 'Issuer', 'INN', 'OKPO', 'stock', 'index', 'TQBR', null]]
-        },
-        description: { columns: ['name', 'value'], data: [['description', 'RTS Index']] },
-        boards: { columns: ['boardid', 'engine', 'market', 'boardname', 'active', 'primary'], data: [['TQBR', 'stock', 'index', 'Main', 1, 1]] }
-    }).persist();
+	nock("https://iss.moex.com").get("/iss/securities/RTSI.json").reply(200, {
+		securities: {
+			columns: ["secid", "shortname", "regnumber", "name", "isin", "is_traded", "emitent_id", "emitent_title", "emitent_inn", "emitent_okpo", "type", "group", "primary_boardid", "marketprice_boardid"],
+			data: [["RTSI", "RTS Index", "123", "RTS Index", "RU123", 1, 1, "Issuer", "INN", "OKPO", "stock", "index", "TQBR", null]]
+		},
+		description: { columns: ["name", "value"], data: [["description", "RTS Index"]] },
+		boards: { columns: ["boardid", "engine", "market", "boardname", "active", "primary"], data: [["TQBR", "stock", "index", "Main", 1, 1]] }
+	}).persist();
 
-    nock('https://iss.moex.com').get('/iss/securities/SBER.json').reply(200, {
-        securities: {
-            columns: ['secid', 'shortname', 'regnumber', 'name', 'isin', 'is_traded', 'emitent_id', 'emitent_title', 'emitent_inn', 'emitent_okpo', 'type', 'group', 'primary_boardid', 'marketprice_boardid'],
-            data: [['SBER', 'Sberbank', '123', 'Sberbank of Russia', 'RU123', 1, 1, 'Issuer', 'INN', 'OKPO', 'stock', 'shares', 'TQBR', null]]
-        },
-        description: { columns: ['name', 'value'], data: [['description', 'Sberbank']] },
-        boards: { columns: ['boardid', 'engine', 'market', 'boardname', 'active', 'primary'], data: [['TQBR', 'stock', 'shares', 'Main', 1, 1]] }
-    }).persist();
+	nock("https://iss.moex.com").get("/iss/securities/SBER.json").reply(200, {
+		securities: {
+			columns: ["secid", "shortname", "regnumber", "name", "isin", "is_traded", "emitent_id", "emitent_title", "emitent_inn", "emitent_okpo", "type", "group", "primary_boardid", "marketprice_boardid"],
+			data: [["SBER", "Sberbank", "123", "Sberbank of Russia", "RU123", 1, 1, "Issuer", "INN", "OKPO", "stock", "shares", "TQBR", null]]
+		},
+		description: { columns: ["name", "value"], data: [["description", "Sberbank"]] },
+		boards: { columns: ["boardid", "engine", "market", "boardname", "active", "primary"], data: [["TQBR", "stock", "shares", "Main", 1, 1]] }
+	}).persist();
 
-    // securitiesDataRaw for currency/selt - UPPER CASE
-    nock('https://iss.moex.com').get('/iss/engines/currency/markets/selt/securities.json').query(true).reply(function(uri) {
-        const url = new URL(uri, 'https://iss.moex.com');
-        const first = parseInt(url.searchParams.get('first') || '50', 10);
-        const securitiesData = createSecuritiesData(0, first);
-        const marketData = createMarketData(first);
-        return [200, {
-            securities: {
-                columns: ['SECID', 'SHORTNAME', 'REGNUMBER', 'NAME', 'ISIN', 'IS_TRADED', 'EMITENT_ID', 'EMITENT_TITLE', 'EMITENT_INN', 'EMITENT_OKPO', 'TYPE', 'GROUP', 'PRIMARY_BOARDID', 'MARKETPRICE_BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'CURRENCYID'],
-                data: securitiesData
-            },
-            marketdata: {
-                columns: ['SECID', 'BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'LASTCHANGE', 'VALUE', 'VALRUB', 'VOLUME', 'VOLUMERUB', 'TURNOVER', 'VOLTODAY', 'VALTODAY', 'VALTODAY_RUR', 'CURRENCYID', 'TRADEDATE'],
-                data: marketData
-            }
-        }];
-    }).persist();
+	// securitiesDataRaw for currency/selt - UPPER CASE
+	nock("https://iss.moex.com").get("/iss/engines/currency/markets/selt/securities.json").query(true).reply(function(uri) {
+		const url = new URL(uri, "https://iss.moex.com");
+		const first = parseInt(url.searchParams.get("first") || "50", 10);
+		const securitiesData = createSecuritiesData(0, first);
+		const marketData = createMarketData(first);
+		return [200, {
+			securities: {
+				columns: ["SECID", "SHORTNAME", "REGNUMBER", "NAME", "ISIN", "IS_TRADED", "EMITENT_ID", "EMITENT_TITLE", "EMITENT_INN", "EMITENT_OKPO", "TYPE", "GROUP", "PRIMARY_BOARDID", "MARKETPRICE_BOARDID", "LAST", "OPEN", "HIGH", "LOW", "PREVPRICE", "CURRENCYID"],
+				data: securitiesData
+			},
+			marketdata: {
+				columns: ["SECID", "BOARDID", "LAST", "OPEN", "HIGH", "LOW", "PREVPRICE", "LASTCHANGE", "VALUE", "VALRUB", "VOLUME", "VOLUMERUB", "TURNOVER", "VOLTODAY", "VALTODAY", "VALTODAY_RUR", "CURRENCYID", "TRADEDATE"],
+				data: marketData
+			}
+		}];
+	}).persist();
 
-    // securitiesDataRaw for stock/index
-    nock('https://iss.moex.com').get('/iss/engines/stock/markets/index/securities.json').query(true).reply(function(uri) {
-        const url = new URL(uri, 'https://iss.moex.com');
-        const first = parseInt(url.searchParams.get('first') || '50', 10);
-        const securitiesData = createSecuritiesData(0, first);
-        const marketData = createMarketData(first);
-        return [200, {
-            securities: {
-                columns: ['SECID', 'SHORTNAME', 'REGNUMBER', 'NAME', 'ISIN', 'IS_TRADED', 'EMITENT_ID', 'EMITENT_TITLE', 'EMITENT_INN', 'EMITENT_OKPO', 'TYPE', 'GROUP', 'PRIMARY_BOARDID', 'MARKETPRICE_BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'CURRENCYID'],
-                data: securitiesData
-            },
-            marketdata: {
-                columns: ['SECID', 'BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'LASTCHANGE', 'VALUE', 'VALRUB', 'VOLUME', 'VOLUMERUB', 'TURNOVER', 'VOLTODAY', 'VALTODAY', 'VALTODAY_RUR', 'CURRENCYID', 'TRADEDATE'],
-                data: marketData
-            }
-        }];
-    }).persist();
+	// securitiesDataRaw for stock/index
+	nock("https://iss.moex.com").get("/iss/engines/stock/markets/index/securities.json").query(true).reply(function(uri) {
+		const url = new URL(uri, "https://iss.moex.com");
+		const first = parseInt(url.searchParams.get("first") || "50", 10);
+		const securitiesData = createSecuritiesData(0, first);
+		const marketData = createMarketData(first);
+		return [200, {
+			securities: {
+				columns: ["SECID", "SHORTNAME", "REGNUMBER", "NAME", "ISIN", "IS_TRADED", "EMITENT_ID", "EMITENT_TITLE", "EMITENT_INN", "EMITENT_OKPO", "TYPE", "GROUP", "PRIMARY_BOARDID", "MARKETPRICE_BOARDID", "LAST", "OPEN", "HIGH", "LOW", "PREVPRICE", "CURRENCYID"],
+				data: securitiesData
+			},
+			marketdata: {
+				columns: ["SECID", "BOARDID", "LAST", "OPEN", "HIGH", "LOW", "PREVPRICE", "LASTCHANGE", "VALUE", "VALRUB", "VOLUME", "VOLUMERUB", "TURNOVER", "VOLTODAY", "VALTODAY", "VALTODAY_RUR", "CURRENCYID", "TRADEDATE"],
+				data: marketData
+			}
+		}];
+	}).persist();
 
-    // security market data for USD000UTSTOM - UPPER CASE
-    nock('https://iss.moex.com').get('/iss/engines/currency/markets/selt/securities/USD000UTSTOM.json').reply(200, {
-        securities: {
-            columns: ['SECID', 'SHORTNAME', 'REGNUMBER', 'NAME', 'ISIN', 'IS_TRADED', 'EMITENT_ID', 'EMITENT_TITLE', 'EMITENT_INN', 'EMITENT_OKPO', 'TYPE', 'GROUP', 'PRIMARY_BOARDID', 'MARKETPRICE_BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'CURRENCYID'],
-            data: [['USD000UTSTOM', 'USD/RUB', '123', 'US Dollar', 'US123', 1, 1, 'Issuer', 'INN', 'OKPO', 'currency', 'selt', 'CETS', null, 100, 90, 110, 80, 95, 'RUR']]
-        },
-        marketdata: {
-            columns: ['SECID', 'BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'LASTCHANGE', 'VALUE', 'VALRUB', 'VOLUME', 'VOLUMERUB', 'TURNOVER', 'VOLTODAY', 'VALTODAY', 'VALTODAY_RUR', 'CURRENCYID', 'TRADEDATE'],
-            data: [['USD000UTSTOM', 'CETS', 100, 90, 110, 80, 95, 5, 1000, 5000, 10000, 50000, 100000, 500, 2500, 12500, 'RUR', '2024-01-01']]
-        }
-    }).persist();
+	// security market data for USD000UTSTOM - UPPER CASE
+	nock("https://iss.moex.com").get("/iss/engines/currency/markets/selt/securities/USD000UTSTOM.json").reply(200, {
+		securities: {
+			columns: ["SECID", "SHORTNAME", "REGNUMBER", "NAME", "ISIN", "IS_TRADED", "EMITENT_ID", "EMITENT_TITLE", "EMITENT_INN", "EMITENT_OKPO", "TYPE", "GROUP", "PRIMARY_BOARDID", "MARKETPRICE_BOARDID", "LAST", "OPEN", "HIGH", "LOW", "PREVPRICE", "CURRENCYID"],
+			data: [["USD000UTSTOM", "USD/RUB", "123", "US Dollar", "US123", 1, 1, "Issuer", "INN", "OKPO", "currency", "selt", "CETS", null, 100, 90, 110, 80, 95, "RUR"]]
+		},
+		marketdata: {
+			columns: ["SECID", "BOARDID", "LAST", "OPEN", "HIGH", "LOW", "PREVPRICE", "LASTCHANGE", "VALUE", "VALRUB", "VOLUME", "VOLUMERUB", "TURNOVER", "VOLTODAY", "VALTODAY", "VALTODAY_RUR", "CURRENCYID", "TRADEDATE"],
+			data: [["USD000UTSTOM", "CETS", 100, 90, 110, 80, 95, 5, 1000, 5000, 10000, 50000, 100000, 500, 2500, 12500, "RUR", "2024-01-01"]]
+		}
+	}).persist();
 
-    // security market data for IMOEX - UPPER CASE
-    nock('https://iss.moex.com').get('/iss/engines/stock/markets/index/securities/IMOEX.json').reply(200, {
-        securities: {
-            columns: ['SECID', 'SHORTNAME', 'REGNUMBER', 'NAME', 'ISIN', 'IS_TRADED', 'EMITENT_ID', 'EMITENT_TITLE', 'EMITENT_INN', 'EMITENT_OKPO', 'TYPE', 'GROUP', 'PRIMARY_BOARDID', 'MARKETPRICE_BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'CURRENCYID'],
-            data: [['IMOEX', 'MOEX Index', '123', 'Moscow Exchange Index', 'RU123', 1, 1, 'Issuer', 'INN', 'OKPO', 'stock', 'index', 'TQBR', null, 2500, 2490, 2510, 2480, 2495, null]]
-        },
-        marketdata: {
-            columns: ['SECID', 'BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'LASTCHANGE', 'VALUE', 'VALRUB', 'VOLUME', 'VOLUMERUB', 'TURNOVER', 'VOLTODAY', 'VALTODAY', 'VALTODAY_RUR', 'CURRENCYID', 'TRADEDATE'],
-            data: [['IMOEX', 'TQBR', 2500, 2490, 2510, 2480, 2495, 5, 1000000, 5000000, 100000, 5000000, 100000000, 5000, 25000, 125000, null, '2024-01-01']]
-        }
-    }).persist();
+	// security market data for IMOEX - UPPER CASE
+	nock("https://iss.moex.com").get("/iss/engines/stock/markets/index/securities/IMOEX.json").reply(200, {
+		securities: {
+			columns: ["SECID", "SHORTNAME", "REGNUMBER", "NAME", "ISIN", "IS_TRADED", "EMITENT_ID", "EMITENT_TITLE", "EMITENT_INN", "EMITENT_OKPO", "TYPE", "GROUP", "PRIMARY_BOARDID", "MARKETPRICE_BOARDID", "LAST", "OPEN", "HIGH", "LOW", "PREVPRICE", "CURRENCYID"],
+			data: [["IMOEX", "MOEX Index", "123", "Moscow Exchange Index", "RU123", 1, 1, "Issuer", "INN", "OKPO", "stock", "index", "TQBR", null, 2500, 2490, 2510, 2480, 2495, null]]
+		},
+		marketdata: {
+			columns: ["SECID", "BOARDID", "LAST", "OPEN", "HIGH", "LOW", "PREVPRICE", "LASTCHANGE", "VALUE", "VALRUB", "VOLUME", "VOLUMERUB", "TURNOVER", "VOLTODAY", "VALTODAY", "VALTODAY_RUR", "CURRENCYID", "TRADEDATE"],
+			data: [["IMOEX", "TQBR", 2500, 2490, 2510, 2480, 2495, 5, 1000000, 5000000, 100000, 5000000, 100000000, 5000, 25000, 125000, null, "2024-01-01"]]
+		}
+	}).persist();
 
-    // security market data for RTSI - UPPER CASE
-    nock('https://iss.moex.com').get('/iss/engines/stock/markets/index/securities/RTSI.json').reply(200, {
-        securities: {
-            columns: ['SECID', 'SHORTNAME', 'REGNUMBER', 'NAME', 'ISIN', 'IS_TRADED', 'EMITENT_ID', 'EMITENT_TITLE', 'EMITENT_INN', 'EMITENT_OKPO', 'TYPE', 'GROUP', 'PRIMARY_BOARDID', 'MARKETPRICE_BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'CURRENCYID'],
-            data: [['RTSI', 'RTS Index', '123', 'RTS Index', 'RU123', 1, 1, 'Issuer', 'INN', 'OKPO', 'stock', 'index', 'TQBR', null, 1000, 990, 1010, 980, 995, null]]
-        },
-        marketdata: {
-            columns: ['SECID', 'BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'LASTCHANGE', 'VALUE', 'VALRUB', 'VOLUME', 'VOLUMERUB', 'TURNOVER', 'VOLTODAY', 'VALTODAY', 'VALTODAY_RUR', 'CURRENCYID', 'TRADEDATE'],
-            data: [['RTSI', 'TQBR', 1000, 990, 1010, 980, 995, 5, 500000, 2500000, 50000, 2500000, 50000000, 2500, 12500, 62500, null, '2024-01-01']]
-        }
-    }).persist();
+	// security market data for RTSI - UPPER CASE
+	nock("https://iss.moex.com").get("/iss/engines/stock/markets/index/securities/RTSI.json").reply(200, {
+		securities: {
+			columns: ["SECID", "SHORTNAME", "REGNUMBER", "NAME", "ISIN", "IS_TRADED", "EMITENT_ID", "EMITENT_TITLE", "EMITENT_INN", "EMITENT_OKPO", "TYPE", "GROUP", "PRIMARY_BOARDID", "MARKETPRICE_BOARDID", "LAST", "OPEN", "HIGH", "LOW", "PREVPRICE", "CURRENCYID"],
+			data: [["RTSI", "RTS Index", "123", "RTS Index", "RU123", 1, 1, "Issuer", "INN", "OKPO", "stock", "index", "TQBR", null, 1000, 990, 1010, 980, 995, null]]
+		},
+		marketdata: {
+			columns: ["SECID", "BOARDID", "LAST", "OPEN", "HIGH", "LOW", "PREVPRICE", "LASTCHANGE", "VALUE", "VALRUB", "VOLUME", "VOLUMERUB", "TURNOVER", "VOLTODAY", "VALTODAY", "VALTODAY_RUR", "CURRENCYID", "TRADEDATE"],
+			data: [["RTSI", "TQBR", 1000, 990, 1010, 980, 995, 5, 500000, 2500000, 50000, 2500000, 50000000, 2500, 12500, 62500, null, "2024-01-01"]]
+		}
+	}).persist();
 
-    // security market data for SBER - UPPER CASE
-    nock('https://iss.moex.com').get('/iss/engines/stock/markets/shares/securities/SBER.json').reply(200, {
-        securities: {
-            columns: ['SECID', 'SHORTNAME', 'REGNUMBER', 'NAME', 'ISIN', 'IS_TRADED', 'EMITENT_ID', 'EMITENT_TITLE', 'EMITENT_INN', 'EMITENT_OKPO', 'TYPE', 'GROUP', 'PRIMARY_BOARDID', 'MARKETPRICE_BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'CURRENCYID'],
-            data: [['SBER', 'Sberbank', '123', 'Sberbank of Russia', 'RU123', 1, 1, 'Issuer', 'INN', 'OKPO', 'stock', 'shares', 'TQBR', null, 250, 249, 251, 248, 249, 'RUR']]
-        },
-        marketdata: {
-            columns: ['SECID', 'BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'LASTCHANGE', 'VALUE', 'VALRUB', 'VOLUME', 'VOLUMERUB', 'TURNOVER', 'VOLTODAY', 'VALTODAY', 'VALTODAY_RUR', 'CURRENCYID', 'TRADEDATE'],
-            data: [['SBER', 'TQBR', 250, 249, 251, 248, 249, 1, 2000000, 10000000, 200000, 10000000, 200000000, 10000, 50000, 250000, 'RUR', '2024-01-01']]
-        }
-    }).persist();
+	// security market data for SBER - UPPER CASE
+	nock("https://iss.moex.com").get("/iss/engines/stock/markets/shares/securities/SBER.json").reply(200, {
+		securities: {
+			columns: ["SECID", "SHORTNAME", "REGNUMBER", "NAME", "ISIN", "IS_TRADED", "EMITENT_ID", "EMITENT_TITLE", "EMITENT_INN", "EMITENT_OKPO", "TYPE", "GROUP", "PRIMARY_BOARDID", "MARKETPRICE_BOARDID", "LAST", "OPEN", "HIGH", "LOW", "PREVPRICE", "CURRENCYID"],
+			data: [["SBER", "Sberbank", "123", "Sberbank of Russia", "RU123", 1, 1, "Issuer", "INN", "OKPO", "stock", "shares", "TQBR", null, 250, 249, 251, 248, 249, "RUR"]]
+		},
+		marketdata: {
+			columns: ["SECID", "BOARDID", "LAST", "OPEN", "HIGH", "LOW", "PREVPRICE", "LASTCHANGE", "VALUE", "VALRUB", "VOLUME", "VOLUMERUB", "TURNOVER", "VOLTODAY", "VALTODAY", "VALTODAY_RUR", "CURRENCYID", "TRADEDATE"],
+			data: [["SBER", "TQBR", 250, 249, 251, 248, 249, 1, 2000000, 10000000, 200000, 10000000, 200000000, 10000, 50000, 250000, "RUR", "2024-01-01"]]
+		}
+	}).persist();
 };
 
 module.exports = { setupMocks, nock };
 
 // Dummy test to prevent Jest from failing on this file
 describe("Mock utilities", () => {
-    test("should export setupMocks function", () => {
-        expect(typeof setupMocks).toBe("function");
-        expect(typeof nock).toBe("function");
-    });
+	test("should export setupMocks function", () => {
+		expect(typeof setupMocks).toBe("function");
+		expect(typeof nock).toBe("function");
+	});
 });

--- a/test/_mocks.js
+++ b/test/_mocks.js
@@ -1,0 +1,206 @@
+const nock = require('nock');
+
+const createSecuritiesData = (start, count) => {
+    const data = [];
+    for (let i = 0; i < count; i++) {
+        const secid = `SEC${String(start + i).padStart(4, '0')}`;
+        data.push([
+            secid, `Security ${start + i}`, '123', `Full name ${start + i}`, 'ISIN123',
+            1, 1, 'Issuer', 'INN123', 'OKPO123', 'stock', 'group1', 'CETS', null
+        ]);
+    }
+    return data;
+};
+
+const createMarketData = (count) => {
+    const data = [];
+    for (let i = 0; i < count; i++) {
+        const secid = `SEC${String(i).padStart(4, '0')}`;
+        data.push([
+            secid, 'CETS', 100 + i, 90 + i, 110 + i, 80 + i, 95 + i, 5 + i,
+            1000 + i * 10, 5000 + i * 50, 10000 + i * 100, 50000 + i * 500,
+            100000 + i * 1000, 500 + i * 5, 2500 + i * 25, 12500 + i * 125, 'RUR', '2024-01-01'
+        ]);
+    }
+    return data;
+};
+
+const setupMocks = () => {
+    nock.disableNetConnect();
+
+    // engines endpoint - camelCase
+    nock('https://iss.moex.com').get('/iss/engines.json').reply(200, {
+        engines: {
+            columns: ['name', 'description'],
+            data: [['stock', 'Stocks'], ['currency', 'Currency'], ['futures', 'Futures'], ['bond', 'Bonds'], ['marketdata', 'Market Data']]
+        }
+    }).persist();
+
+    // index endpoint - camelCase
+    nock('https://iss.moex.com').get('/iss.json').reply(200, {
+        engines: { columns: ['name'], data: [['stock'], ['currency'], ['futures'], ['bond'], ['marketdata']] },
+        markets: { columns: ['name'], data: [['shares'], ['selt'], ['index'], ['derivatives'], ['bonds']] },
+        boards: { columns: ['boardid'], data: [['CETS'], ['TQBR'], ['RFUD'], ['RFLS'], ['INAV']] }
+    }).persist();
+
+    // securities definitions - camelCase, query(true) для гибкого сопоставления
+    nock('https://iss.moex.com').get('/iss/securities.json').query(true).reply(function(uri) {
+        const url = new URL(uri, 'https://iss.moex.com');
+        const start = parseInt(url.searchParams.get('start') || '0', 10);
+        const count = Math.min(100, 500 - start);
+        const data = createSecuritiesData(start, count);
+        return [200, {
+            securities: {
+                columns: ['secid', 'shortname', 'regnumber', 'name', 'isin', 'is_traded', 'emitent_id', 'emitent_title', 'emitent_inn', 'emitent_okpo', 'type', 'group', 'primary_boardid', 'marketprice_boardid'],
+                data: data
+            }
+        }];
+    }).persist();
+
+    // markets endpoint - camelCase
+    nock('https://iss.moex.com').get('/iss/engines/stock/markets.json').reply(200, {
+        markets: {
+            columns: ['NAME', 'DESCRIPTION'],
+            data: [['shares', 'Shares'], ['index', 'Indexes'], ['derivatives', 'Derivatives'], ['bonds', 'Bonds'], ['futures', 'Futures']]
+        }
+    }).persist();
+
+    // boards endpoint - camelCase
+    nock('https://iss.moex.com').get('/iss/engines/currency/markets/selt/boards.json').reply(200, {
+        boards: {
+            columns: ['boardid', 'engine', 'market', 'boardname', 'active', 'primary'],
+            data: [['CETS', 'currency', 'selt', 'Main', 1, 1], ['TQBR', 'currency', 'selt', 'Secondary', 1, 0]]
+        }
+    }).persist();
+
+    // security definitions - camelCase
+    nock('https://iss.moex.com').get('/iss/securities/USD000UTSTOM.json').reply(200, {
+        securities: {
+            columns: ['secid', 'shortname', 'regnumber', 'name', 'isin', 'is_traded', 'emitent_id', 'emitent_title', 'emitent_inn', 'emitent_okpo', 'type', 'group', 'primary_boardid', 'marketprice_boardid'],
+            data: [['USD000UTSTOM', 'USD/RUB', '123', 'US Dollar', 'US123', 1, 1, 'Issuer', 'INN', 'OKPO', 'currency', 'selt', 'CETS', null]]
+        },
+        description: { columns: ['name', 'value'], data: [['description', 'USD/RUB Security']] },
+        boards: { columns: ['boardid', 'engine', 'market', 'boardname', 'active', 'primary'], data: [['CETS', 'currency', 'selt', 'Main', 1, 1]] }
+    }).persist();
+
+    nock('https://iss.moex.com').get('/iss/securities/IMOEX.json').reply(200, {
+        securities: {
+            columns: ['secid', 'shortname', 'regnumber', 'name', 'isin', 'is_traded', 'emitent_id', 'emitent_title', 'emitent_inn', 'emitent_okpo', 'type', 'group', 'primary_boardid', 'marketprice_boardid'],
+            data: [['IMOEX', 'MOEX Index', '123', 'Moscow Exchange Index', 'RU123', 1, 1, 'Issuer', 'INN', 'OKPO', 'stock', 'index', 'TQBR', null]]
+        },
+        description: { columns: ['name', 'value'], data: [['description', 'MOEX Index']] },
+        boards: { columns: ['boardid', 'engine', 'market', 'boardname', 'active', 'primary'], data: [['TQBR', 'stock', 'index', 'Main', 1, 1]] }
+    }).persist();
+
+    nock('https://iss.moex.com').get('/iss/securities/RTSI.json').reply(200, {
+        securities: {
+            columns: ['secid', 'shortname', 'regnumber', 'name', 'isin', 'is_traded', 'emitent_id', 'emitent_title', 'emitent_inn', 'emitent_okpo', 'type', 'group', 'primary_boardid', 'marketprice_boardid'],
+            data: [['RTSI', 'RTS Index', '123', 'RTS Index', 'RU123', 1, 1, 'Issuer', 'INN', 'OKPO', 'stock', 'index', 'TQBR', null]]
+        },
+        description: { columns: ['name', 'value'], data: [['description', 'RTS Index']] },
+        boards: { columns: ['boardid', 'engine', 'market', 'boardname', 'active', 'primary'], data: [['TQBR', 'stock', 'index', 'Main', 1, 1]] }
+    }).persist();
+
+    nock('https://iss.moex.com').get('/iss/securities/SBER.json').reply(200, {
+        securities: {
+            columns: ['secid', 'shortname', 'regnumber', 'name', 'isin', 'is_traded', 'emitent_id', 'emitent_title', 'emitent_inn', 'emitent_okpo', 'type', 'group', 'primary_boardid', 'marketprice_boardid'],
+            data: [['SBER', 'Sberbank', '123', 'Sberbank of Russia', 'RU123', 1, 1, 'Issuer', 'INN', 'OKPO', 'stock', 'shares', 'TQBR', null]]
+        },
+        description: { columns: ['name', 'value'], data: [['description', 'Sberbank']] },
+        boards: { columns: ['boardid', 'engine', 'market', 'boardname', 'active', 'primary'], data: [['TQBR', 'stock', 'shares', 'Main', 1, 1]] }
+    }).persist();
+
+    // securitiesDataRaw for currency/selt - UPPER CASE
+    nock('https://iss.moex.com').get('/iss/engines/currency/markets/selt/securities.json').query(true).reply(function(uri) {
+        const url = new URL(uri, 'https://iss.moex.com');
+        const first = parseInt(url.searchParams.get('first') || '50', 10);
+        const securitiesData = createSecuritiesData(0, first);
+        const marketData = createMarketData(first);
+        return [200, {
+            securities: {
+                columns: ['SECID', 'SHORTNAME', 'REGNUMBER', 'NAME', 'ISIN', 'IS_TRADED', 'EMITENT_ID', 'EMITENT_TITLE', 'EMITENT_INN', 'EMITENT_OKPO', 'TYPE', 'GROUP', 'PRIMARY_BOARDID', 'MARKETPRICE_BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'CURRENCYID'],
+                data: securitiesData
+            },
+            marketdata: {
+                columns: ['SECID', 'BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'LASTCHANGE', 'VALUE', 'VALRUB', 'VOLUME', 'VOLUMERUB', 'TURNOVER', 'VOLTODAY', 'VALTODAY', 'VALTODAY_RUR', 'CURRENCYID', 'TRADEDATE'],
+                data: marketData
+            }
+        }];
+    }).persist();
+
+    // securitiesDataRaw for stock/index
+    nock('https://iss.moex.com').get('/iss/engines/stock/markets/index/securities.json').query(true).reply(function(uri) {
+        const url = new URL(uri, 'https://iss.moex.com');
+        const first = parseInt(url.searchParams.get('first') || '50', 10);
+        const securitiesData = createSecuritiesData(0, first);
+        const marketData = createMarketData(first);
+        return [200, {
+            securities: {
+                columns: ['SECID', 'SHORTNAME', 'REGNUMBER', 'NAME', 'ISIN', 'IS_TRADED', 'EMITENT_ID', 'EMITENT_TITLE', 'EMITENT_INN', 'EMITENT_OKPO', 'TYPE', 'GROUP', 'PRIMARY_BOARDID', 'MARKETPRICE_BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'CURRENCYID'],
+                data: securitiesData
+            },
+            marketdata: {
+                columns: ['SECID', 'BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'LASTCHANGE', 'VALUE', 'VALRUB', 'VOLUME', 'VOLUMERUB', 'TURNOVER', 'VOLTODAY', 'VALTODAY', 'VALTODAY_RUR', 'CURRENCYID', 'TRADEDATE'],
+                data: marketData
+            }
+        }];
+    }).persist();
+
+    // security market data for USD000UTSTOM - UPPER CASE
+    nock('https://iss.moex.com').get('/iss/engines/currency/markets/selt/securities/USD000UTSTOM.json').reply(200, {
+        securities: {
+            columns: ['SECID', 'SHORTNAME', 'REGNUMBER', 'NAME', 'ISIN', 'IS_TRADED', 'EMITENT_ID', 'EMITENT_TITLE', 'EMITENT_INN', 'EMITENT_OKPO', 'TYPE', 'GROUP', 'PRIMARY_BOARDID', 'MARKETPRICE_BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'CURRENCYID'],
+            data: [['USD000UTSTOM', 'USD/RUB', '123', 'US Dollar', 'US123', 1, 1, 'Issuer', 'INN', 'OKPO', 'currency', 'selt', 'CETS', null, 100, 90, 110, 80, 95, 'RUR']]
+        },
+        marketdata: {
+            columns: ['SECID', 'BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'LASTCHANGE', 'VALUE', 'VALRUB', 'VOLUME', 'VOLUMERUB', 'TURNOVER', 'VOLTODAY', 'VALTODAY', 'VALTODAY_RUR', 'CURRENCYID', 'TRADEDATE'],
+            data: [['USD000UTSTOM', 'CETS', 100, 90, 110, 80, 95, 5, 1000, 5000, 10000, 50000, 100000, 500, 2500, 12500, 'RUR', '2024-01-01']]
+        }
+    }).persist();
+
+    // security market data for IMOEX - UPPER CASE
+    nock('https://iss.moex.com').get('/iss/engines/stock/markets/index/securities/IMOEX.json').reply(200, {
+        securities: {
+            columns: ['SECID', 'SHORTNAME', 'REGNUMBER', 'NAME', 'ISIN', 'IS_TRADED', 'EMITENT_ID', 'EMITENT_TITLE', 'EMITENT_INN', 'EMITENT_OKPO', 'TYPE', 'GROUP', 'PRIMARY_BOARDID', 'MARKETPRICE_BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'CURRENCYID'],
+            data: [['IMOEX', 'MOEX Index', '123', 'Moscow Exchange Index', 'RU123', 1, 1, 'Issuer', 'INN', 'OKPO', 'stock', 'index', 'TQBR', null, 2500, 2490, 2510, 2480, 2495, null]]
+        },
+        marketdata: {
+            columns: ['SECID', 'BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'LASTCHANGE', 'VALUE', 'VALRUB', 'VOLUME', 'VOLUMERUB', 'TURNOVER', 'VOLTODAY', 'VALTODAY', 'VALTODAY_RUR', 'CURRENCYID', 'TRADEDATE'],
+            data: [['IMOEX', 'TQBR', 2500, 2490, 2510, 2480, 2495, 5, 1000000, 5000000, 100000, 5000000, 100000000, 5000, 25000, 125000, null, '2024-01-01']]
+        }
+    }).persist();
+
+    // security market data for RTSI - UPPER CASE
+    nock('https://iss.moex.com').get('/iss/engines/stock/markets/index/securities/RTSI.json').reply(200, {
+        securities: {
+            columns: ['SECID', 'SHORTNAME', 'REGNUMBER', 'NAME', 'ISIN', 'IS_TRADED', 'EMITENT_ID', 'EMITENT_TITLE', 'EMITENT_INN', 'EMITENT_OKPO', 'TYPE', 'GROUP', 'PRIMARY_BOARDID', 'MARKETPRICE_BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'CURRENCYID'],
+            data: [['RTSI', 'RTS Index', '123', 'RTS Index', 'RU123', 1, 1, 'Issuer', 'INN', 'OKPO', 'stock', 'index', 'TQBR', null, 1000, 990, 1010, 980, 995, null]]
+        },
+        marketdata: {
+            columns: ['SECID', 'BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'LASTCHANGE', 'VALUE', 'VALRUB', 'VOLUME', 'VOLUMERUB', 'TURNOVER', 'VOLTODAY', 'VALTODAY', 'VALTODAY_RUR', 'CURRENCYID', 'TRADEDATE'],
+            data: [['RTSI', 'TQBR', 1000, 990, 1010, 980, 995, 5, 500000, 2500000, 50000, 2500000, 50000000, 2500, 12500, 62500, null, '2024-01-01']]
+        }
+    }).persist();
+
+    // security market data for SBER - UPPER CASE
+    nock('https://iss.moex.com').get('/iss/engines/stock/markets/shares/securities/SBER.json').reply(200, {
+        securities: {
+            columns: ['SECID', 'SHORTNAME', 'REGNUMBER', 'NAME', 'ISIN', 'IS_TRADED', 'EMITENT_ID', 'EMITENT_TITLE', 'EMITENT_INN', 'EMITENT_OKPO', 'TYPE', 'GROUP', 'PRIMARY_BOARDID', 'MARKETPRICE_BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'CURRENCYID'],
+            data: [['SBER', 'Sberbank', '123', 'Sberbank of Russia', 'RU123', 1, 1, 'Issuer', 'INN', 'OKPO', 'stock', 'shares', 'TQBR', null, 250, 249, 251, 248, 249, 'RUR']]
+        },
+        marketdata: {
+            columns: ['SECID', 'BOARDID', 'LAST', 'OPEN', 'HIGH', 'LOW', 'PREVPRICE', 'LASTCHANGE', 'VALUE', 'VALRUB', 'VOLUME', 'VOLUMERUB', 'TURNOVER', 'VOLTODAY', 'VALTODAY', 'VALTODAY_RUR', 'CURRENCYID', 'TRADEDATE'],
+            data: [['SBER', 'TQBR', 250, 249, 251, 248, 249, 1, 2000000, 10000000, 200000, 10000000, 200000000, 10000, 50000, 250000, 'RUR', '2024-01-01']]
+        }
+    }).persist();
+};
+
+module.exports = { setupMocks, nock };
+
+// Dummy test to prevent Jest from failing on this file
+describe("Mock utilities", () => {
+    test("should export setupMocks function", () => {
+        expect(typeof setupMocks).toBe("function");
+        expect(typeof nock).toBe("function");
+    });
+});

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -1,4 +1,18 @@
 const MoexAPI = require("../api");
+const { setupMocks, nock } = require("./_mocks");
+
+beforeAll(() => {
+	setupMocks();
+});
+
+afterAll(() => {
+	nock.cleanAll();
+	nock.enableNetConnect();
+});
+
+afterEach(() => {
+	setupMocks();
+});
 
 describe("MoexAPI.", () => {
 


### PR DESCRIPTION
## Changes
- Create test/_mocks.js with persistent nock mocks for all API endpoints
- Update test/test-api.js to use mocks with beforeAll/afterEach
- Add nock@13.5.4 as devDependency
- All 27 tests now pass without real API calls

## Testing
All tests pass without network calls:
- 27/27 tests passing
- No external API dependencies in test suite